### PR TITLE
Added Harvester HCI to installers page.

### DIFF
--- a/docs/installers/installers.md
+++ b/docs/installers/installers.md
@@ -8,6 +8,7 @@ Installers
 * [Docker for MAC](https://store.docker.com/editions/community/docker-ce-desktop-mac) - Run Kubernetes and Docker locally on your MAC (Edge Channel)
 * [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) - Run Kubernetes and Docker locally on your Windows PC (Edge Channel)
 * [eksctl](https://eksctl.io/) - The official CLI for Amazon EKS
+* [Harvester](https://github.com/harvester/harvester) - Easily deploy and manage Kubernete clusters across multiple nodes. Includes Rancher, Longhorn, and KubeVirt, built on-top of K3OS.
 * [Juju](https://jaas.ai/canonical-kubernetes) - Ubuntu - Cloud Agnostic
 * [Krucible](https://usekrucible.com/) - Create temporary Kubernetes clusters for testing and development (no account required)
 * [KubeSphere](https://github.com/kubesphere/kubesphere) - Install Kubernetes and KubeSphere in multiple instances in an easy way, including full-stack cloud-native softwares, e.g. istio, ES, Prometheus, Fluent Bit, SonarQube, Jenkins.


### PR DESCRIPTION
Harvester is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of Cloud Native.  Includes Longhor, KubeVirt, built on-top of K3OS. 

Thank You for creating a Pull Request. We appreciate your efforts towards contributing the awesome-kubernetes list.

As a part of our practice, we would like to select the projects based on the below criteria. Please ensure that your submission is fulfilling the below requirements. Thanks

#### Requirements for any project submissions

  **- Minimum of 25 GitHub Stars:** Yes
  **- Minimum of 3+ contributors:** Yes
  **- Proper documentation of the project and its goals:** Yes, see [Harvester Docs](https://docs.harvesterhci.io/v0.2/).

#### Exceptions

  - Project is hosted by a recognized organization. Note, this is a development headed up by Rancher Labs & SUSE.
